### PR TITLE
Introductory documentation on Callbacks and fixed some mutability oversights

### DIFF
--- a/src/devices/digital_output.rs
+++ b/src/devices/digital_output.rs
@@ -56,7 +56,8 @@ impl DigitalOutput {
         })?;
         Ok(())
     }
-    /// Set  duty cycle async
+
+    // /// Set  duty cycle async
     // pub async fn set_duty_cycle_async(&self, duty_cycle: f64) -> Result<()> {
     //     _ = duty_cycle;
     //     unimplemented!();
@@ -150,7 +151,7 @@ impl DigitalOutput {
         Ok(())
     }
 
-    /// Set led current limit async
+    // /// Set led current limit async
     // pub async fn set_led_current_limit_async(&self, led_current_limit: f64) -> Result<()> {
     //     _ = led_current_limit;
     //     unimplemented!()
@@ -198,7 +199,7 @@ impl DigitalOutput {
         ReturnCode::result(unsafe { ffi::PhidgetDigitalOutput_setState(self.chan, state as i32) })
     }
 
-    /// Set state async
+    // /// Set state async
     // pub async fn set_state_async(&self, state: bool) -> Result<()> {
     //     _ = state;
     //     unimplemented!();

--- a/src/devices/stepper.rs
+++ b/src/devices/stepper.rs
@@ -326,7 +326,8 @@ impl Stepper {
         ReturnCode::result(unsafe { ffi::PhidgetStepper_setTargetPosition(self.chan, stepper) })?;
         Ok(())
     }
-    /// [NOT IMPLEMENTED] Set target position async TODO
+
+    // /// [NOT IMPLEMENTED] Set target position async TODO
     // pub async fn set_target_position_async(&self, stepper: f64) -> Result<()> {
     //     _ = stepper;
     //     unimplemented!();


### PR DESCRIPTION
(refers to #10)
 
I made the following changes:
- added an introductory example in the main documentation page
- added example for callbacks
- some setter methods were accepting `&self `instead of `&mut self`, hence not enforcing the rust mutability rules
- there were leftovers of some async methods. However, while the method was commented out, its docstring wasn't, so it was leaking into the documentation of the next method