### PR TITLE
Implemented Fidget Manager

### DIFF
--- a/src/devices/digital_input.rs
+++ b/src/devices/digital_input.rs
@@ -196,9 +196,13 @@ impl DigitalInput {
 }
 
 impl Phidget for DigitalInput {
-    fn as_handle(&mut self) -> PhidgetHandle {
+    fn as_mut_handle(&mut self) -> PhidgetHandle {
         self.chan as PhidgetHandle
     }
+    fn as_handle(&self) -> PhidgetHandle {
+        self.chan as PhidgetHandle
+    }
+
 }
 
 unsafe impl Send for DigitalInput {}

--- a/src/devices/digital_output.rs
+++ b/src/devices/digital_output.rs
@@ -237,7 +237,10 @@ impl DigitalOutput {
 }
 
 impl Phidget for DigitalOutput {
-    fn as_handle(&mut self) -> PhidgetHandle {
+    fn as_mut_handle(&mut self) -> PhidgetHandle {
+        self.chan as PhidgetHandle
+    }
+    fn as_handle(&self) -> PhidgetHandle {
         self.chan as PhidgetHandle
     }
 }

--- a/src/devices/hub.rs
+++ b/src/devices/hub.rs
@@ -107,7 +107,10 @@ impl Hub {
 }
 
 impl Phidget for Hub {
-    fn as_handle(&mut self) -> PhidgetHandle {
+    fn as_mut_handle(&mut self) -> PhidgetHandle {
+        self.chan as PhidgetHandle
+    }
+    fn as_handle(&self) -> PhidgetHandle {
         self.chan as PhidgetHandle
     }
 }

--- a/src/devices/humidity_sensor.rs
+++ b/src/devices/humidity_sensor.rs
@@ -113,7 +113,10 @@ impl HumiditySensor {
 }
 
 impl Phidget for HumiditySensor {
-    fn as_handle(&mut self) -> PhidgetHandle {
+    fn as_mut_handle(&mut self) -> PhidgetHandle {
+        self.chan as PhidgetHandle
+    }
+    fn as_handle(&self) -> PhidgetHandle {
         self.chan as PhidgetHandle
     }
 }

--- a/src/devices/stepper.rs
+++ b/src/devices/stepper.rs
@@ -483,9 +483,13 @@ impl Stepper {
 }
 
 impl Phidget for Stepper {
-    fn as_handle(&mut self) -> PhidgetHandle {
+    fn as_mut_handle(&mut self) -> PhidgetHandle {
         self.chan as PhidgetHandle
     }
+    fn as_handle(&self) -> PhidgetHandle {
+        self.chan as PhidgetHandle
+    }
+
 }
 
 unsafe impl Send for Stepper {}

--- a/src/devices/temperature_sensor.rs
+++ b/src/devices/temperature_sensor.rs
@@ -111,7 +111,10 @@ impl TemperatureSensor {
 }
 
 impl Phidget for TemperatureSensor {
-    fn as_handle(&mut self) -> PhidgetHandle {
+    fn as_mut_handle(&mut self) -> PhidgetHandle {
+        self.chan as PhidgetHandle
+    }
+    fn as_handle(&self) -> PhidgetHandle {
         self.chan as PhidgetHandle
     }
 }

--- a/src/devices/voltage_input.rs
+++ b/src/devices/voltage_input.rs
@@ -109,7 +109,10 @@ impl VoltageInput {
 }
 
 impl Phidget for VoltageInput {
-    fn as_handle(&mut self) -> PhidgetHandle {
+    fn as_mut_handle(&mut self) -> PhidgetHandle {
+        self.chan as PhidgetHandle
+    }
+    fn as_handle(&self) -> PhidgetHandle {
         self.chan as PhidgetHandle
     }
 }

--- a/src/devices/voltage_output.rs
+++ b/src/devices/voltage_output.rs
@@ -68,7 +68,10 @@ impl VoltageOutput {
 }
 
 impl Phidget for VoltageOutput {
-    fn as_handle(&mut self) -> PhidgetHandle {
+    fn as_mut_handle(&mut self) -> PhidgetHandle {
+        self.chan as PhidgetHandle
+    }
+    fn as_handle(&self) -> PhidgetHandle {
         self.chan as PhidgetHandle
     }
 }

--- a/src/devices/voltage_ratio_input.rs
+++ b/src/devices/voltage_ratio_input.rs
@@ -109,7 +109,10 @@ impl VoltageRatioInput {
 }
 
 impl Phidget for VoltageRatioInput {
-    fn as_handle(&mut self) -> PhidgetHandle {
+    fn as_mut_handle(&mut self) -> PhidgetHandle {
+        self.chan as PhidgetHandle
+    }
+    fn as_handle(&self) -> PhidgetHandle {
         self.chan as PhidgetHandle
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ pub use crate::net::ServerType;
 
 /// Module containing all implemented devices
 pub mod devices;
+pub mod manager;
 
 // For v0.1.x compatibility, sensors available at the root
 pub use crate::devices::{

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,0 +1,128 @@
+// phidget-rs/src/manager.rs
+//
+// Copyright (c) 2025 Guillaume Schmid
+//
+// This file is part of the 'phidget-rs' library.
+//
+// Licensed under the MIT license:
+//   <LICENSE or http://opensource.org/licenses/MIT>
+// This file may not be copied, modified, or distributed except according
+// to those terms.
+//
+//! this is the PhidgetManager struct. It allows discovery of the connected
+//! phidgets and provides a way to handle connect/disconnect event.
+//!
+
+use std::os::raw::c_void;
+use std::ptr;
+use phidget_sys::{PhidgetHandle, PhidgetManagerHandle};
+use crate::{ffi, GenericPhidget, ReturnCode};
+
+/// The signature for device attach callbacks
+pub type ManagerAttachCallback = dyn Fn(&GenericPhidget) + Send + 'static;
+
+/// The signature for device detach callbacks
+pub type ManagerDetachCallback = dyn Fn(&GenericPhidget) + Send + 'static;
+
+
+// Low-level, unsafe callback for device attach events
+unsafe extern "C" fn on_attach_device(_: PhidgetManagerHandle, ctx: *mut c_void, phid: PhidgetHandle) {
+    if !ctx.is_null() {
+        let cb: &mut Box<ManagerAttachCallback> = &mut *(ctx as *mut _);
+        let ph = GenericPhidget::from(phid);
+        cb(&ph);
+    }
+}
+
+// Low-level, unsafe callback for device detach events
+unsafe extern "C" fn on_detach_device(_: PhidgetManagerHandle, ctx: *mut c_void, phid: PhidgetHandle) {
+    if !ctx.is_null() {
+        let cb: &mut Box<ManagerDetachCallback> = &mut *(ctx as *mut _);
+        let ph = GenericPhidget::from(phid);
+        cb(&ph);
+    }
+}
+
+/// Phidget temperature sensor
+pub struct PhidgetManager {
+    // Handle to the sensor for the phidget22 library
+    p_man: PhidgetManagerHandle,
+    // Double-boxed attach callback, if registered
+    attach_cb: Option<*mut c_void>,
+    // Double-boxed detach callback, if registered
+    detach_cb: Option<*mut c_void>,
+}
+
+
+impl PhidgetManager {
+    /// Create a new temperature sensor.
+    pub fn new() -> Self {
+        let mut p_man: PhidgetManagerHandle = ptr::null_mut();
+        unsafe {
+            ffi::PhidgetManager_create(&mut p_man);
+        }
+        Self::from(p_man)
+    }
+
+    /// Open a PhidgetManager.
+    pub fn open(&mut self) -> crate::Result<()> {
+        ReturnCode::result(unsafe {
+            ffi::PhidgetManager_open(self.p_man)
+        })
+    }
+
+    /// Close a PhidgetManager.
+    pub fn close(&mut self) -> crate::Result<()> {
+        ReturnCode::result(unsafe {
+            ffi::PhidgetManager_close(self.p_man)
+        })
+    }
+
+    /// Sets a handler to receive attach callbacks
+    pub fn set_on_attach_handler<F>(&mut self, cb: F) -> crate::Result<()>
+    where
+        F: Fn(&GenericPhidget) + Send + 'static,
+    {
+        // 1st box is fat ptr, 2nd is regular pointer.
+        let cb: Box<Box<ManagerAttachCallback>> = Box::new(Box::new(cb));
+        let ctx = Box::into_raw(cb) as *mut c_void;
+
+        ReturnCode::result(unsafe {
+            ffi::PhidgetManager_setOnAttachHandler(self.p_man, Some(on_attach_device), ctx)
+        })?;
+        self.attach_cb = Some(ctx);
+        Ok(())
+    }
+
+    /// Sets a handler to receive detach callbacks
+    pub fn set_on_detach_handler<F>(&mut self, cb: F) -> crate::Result<()>
+    where
+        F: Fn(&GenericPhidget) + Send + 'static,
+    {
+        // 1st box is fat ptr, 2nd is regular pointer.
+        let cb: Box<Box<ManagerDetachCallback>> = Box::new(Box::new(cb));
+        let ctx = Box::into_raw(cb) as *mut c_void;
+
+        ReturnCode::result(unsafe {
+            ffi::PhidgetManager_setOnDetachHandler(self.p_man, Some(on_detach_device), ctx)
+        })?;
+        self.detach_cb = Some(ctx);
+        Ok(())
+    }
+}
+
+impl From<PhidgetManagerHandle> for PhidgetManager {
+    fn from(p_man: PhidgetManagerHandle) -> Self {
+        PhidgetManager {
+            p_man,
+            attach_cb: None,
+            detach_cb: None,
+        }
+    }
+}
+
+impl Drop for PhidgetManager {
+    fn drop(&mut self) {
+        let _ = unsafe { ffi::PhidgetManager_close(self.p_man) };
+    }
+}


### PR DESCRIPTION
this PR implements the PhidgetManager.
It can traigger 2 callbacks when it detects Phidget are connected or disconnected.

I changed the Phidget API along the way. The attribute read operation of the phidgets are non mutable now.
It make those function callable in the callbacks.
This part of the patch looks big but it is very simple, I added a as_handle_mut function that returns a mutable handle (it replace the previous as_handle() function, and made as_hande non mutable.

Tested on SBCO4 with 2 temperature phidgets.
Tested also on Linux PC with a hub with 2 temperature phidgets.